### PR TITLE
Bump pytest and psycopg2-binary versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,11 @@ Mako==1.1.4
 MarkupSafe==1.1.1
 packaging==20.9
 pluggy==0.13.1
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.4
 py==1.10.0
 pycodestyle==2.6.0
 pyparsing==2.4.7
-pytest==6.2.3
+pytest==7.1.1
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-editor==1.0.4


### PR DESCRIPTION
I validated that these run properly under intel python 3.9 and 3.10. Mark checked these versions on an M1. I also installed postgres (14.5) and confirmed that this version of psycopg2 connects to the db successfully.

If this looks good, I'll merge this into the other checkpoint branches.