### PR TITLE
Bump psycopg2-binary version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Mako==1.2.0
 MarkupSafe==2.1.1
 packaging==21.3
 pluggy==1.0.0
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
 py==1.11.0
 pycodestyle==2.8.0
 pyparsing==3.0.7


### PR DESCRIPTION
Need to point to a version that haas a binary version in pip, otherwise it will try to build from source, which will fail unless postgresql has already been installed. We don't ask for it to be installed until after having started working on hello-books-api.

Asana: https://app.asana.com/0/0/1204419896214873/f
