### PR TITLE
Remove code from 7a branch that will be introduced in the next lesson 

### DIFF
--- a/app/models/book.py
+++ b/app/models/book.py
@@ -5,14 +5,6 @@ class Book(db.Model):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     title: Mapped[str]
     description: Mapped[str]
-
-    def to_dict(self):
-        book_as_dict = {}
-        book_as_dict["id"] = self.id
-        book_as_dict["title"] = self.title
-        book_as_dict["description"] = self.description
-
-        return book_as_dict
     
     @classmethod
     def from_dict(cls, book_data):

--- a/app/routes/book_routes.py
+++ b/app/routes/book_routes.py
@@ -59,14 +59,24 @@ def get_all_books():
 
     books_response = []
     for book in books:
-        books_response.append(book.to_dict())
+        books_response.append(
+            {
+                "id": book.id,
+                "title": book.title,
+                "description": book.description
+            }
+        )
     return books_response
 
 @books_bp.get("/<book_id>")
 def get_one_book(book_id):
     book = validate_book(book_id)
 
-    return book.to_dict()
+    return {
+        "id": book.id,
+        "title": book.title,
+        "description": book.description,
+    }
 
 @books_bp.put("/<book_id>")
 def update_book(book_id):

--- a/tests/test_book_model.py
+++ b/tests/test_book_model.py
@@ -1,63 +1,6 @@
 from app.models.book import Book
 import pytest
 
-def test_to_dict_no_missing_data():
-    # Arrange
-    test_data = Book(id = 1,
-                    title="Ocean Book",
-                    description="watr 4evr")
-
-    # Act
-    result = test_data.to_dict()
-
-    # Assert
-    assert len(result) == 3
-    assert result["id"] == 1
-    assert result["title"] == "Ocean Book"
-    assert result["description"] == "watr 4evr"
-
-def test_to_dict_missing_id():
-    # Arrange
-    test_data = Book(title="Ocean Book",
-                    description="watr 4evr")
-
-    # Act
-    result = test_data.to_dict()
-
-    # Assert
-    assert len(result) == 3
-    assert result["id"] is None
-    assert result["title"] == "Ocean Book"
-    assert result["description"] == "watr 4evr"
-
-def test_to_dict_missing_title():
-    # Arrange
-    test_data = Book(id=1,
-                    description="watr 4evr")
-
-    # Act
-    result = test_data.to_dict()
-
-    # Assert
-    assert len(result) == 3
-    assert result["id"] == 1
-    assert result["title"] is None
-    assert result["description"] == "watr 4evr"
-
-def test_to_dict_missing_description():
-    # Arrange
-    test_data = Book(id = 1,
-                    title="Ocean Book")
-
-    # Act
-    result = test_data.to_dict()
-
-    # Assert
-    assert len(result) == 3
-    assert result["id"] == 1
-    assert result["title"] == "Ocean Book"
-    assert result["description"] is None
-
 def test_from_dict_returns_book():
     # Arrange
     book_data = {

--- a/tests/test_book_routes.py
+++ b/tests/test_book_routes.py
@@ -7,50 +7,6 @@ def test_get_all_books_with_no_records(client):
     assert response.status_code == 200
     assert response_body == []
 
-def test_get_all_books_with_two_records(client, two_saved_books):
-    # Act
-    response = client.get("/books")
-    response_body = response.get_json()
-
-    # Assert
-    assert response.status_code == 200
-    assert len(response_body) == 2
-    assert response_body[0] == {
-        "id": 1,
-        "title": "Ocean Book",
-        "description": "watr 4evr"
-    }
-    assert response_body[1] == {
-        "id": 2,
-        "title": "Mountain Book",
-        "description": "i luv 2 climb rocks"
-    }
-
-def test_get_all_books_with_title_query_matching_none(client, two_saved_books):
-    # Act
-    data = {'title': 'Desert Book'}
-    response = client.get("/books", query_string = data)
-    response_body = response.get_json()
-
-    # Assert
-    assert response.status_code == 200
-    assert response_body == []
-
-def test_get_all_books_with_title_query_matching_one(client, two_saved_books):
-    # Act
-    data = {'title': 'Ocean Book'}
-    response = client.get("/books", query_string = data)
-    response_body = response.get_json()
-
-    # Assert
-    assert response.status_code == 200
-    assert len(response_body) == 1
-    assert response_body[0] == {
-        "id": 1,
-        "title": "Ocean Book",
-        "description": "watr 4evr"
-    }
-
 def test_get_one_book_succeeds(client, two_saved_books):
     # Act
     response = client.get("/books/1")
@@ -63,24 +19,6 @@ def test_get_one_book_succeeds(client, two_saved_books):
         "title": "Ocean Book",
         "description": "watr 4evr"
     }
-
-def test_get_one_book_missing_record(client, two_saved_books):
-    # Act
-    response = client.get("/books/3")
-    response_body = response.get_json()
-
-    # Assert
-    assert response.status_code == 404
-    assert response_body == {"message":"book 3 not found"}
-
-def test_get_one_book_invalid_id(client, two_saved_books):
-    # Act
-    response = client.get("/books/cat")
-    response_body = response.get_json()
-
-    # Assert
-    assert response.status_code == 400
-    assert response_body == {"message":"book cat invalid"}
 
 def test_create_one_book(client):
     # Act


### PR DESCRIPTION
At some point when cascading changes, some code from the 07b branch (to_dict refactor) got into the 07a branch before those topics are introduced.

Removes `to_dict` function from the `Book` class, and removes changes to the route and test files for the `to_dict` function.

[Asana ticket](https://app.asana.com/0/1205655776549324/1208496538310314/f)